### PR TITLE
Changed the generative model from 'gemini-pro-vision' to 'gemini-pro-vision'.

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -361,7 +361,11 @@ class IdentificationService {
   ];
 
   IdentificationService(this.apiKey) {
-    model = GenerativeModel(model: 'gemini-pro-vision', apiKey: apiKey);
+    model = GenerativeModel(
+      // 'gemini-pro-vision' has been deprecated on July 12, 2024
+      model: 'gemini-1.5-flash',
+      apiKey: apiKey,
+    );
   }
 
   Future<bool> getId(Uint8List pngBytes, String symbolName) async {


### PR DESCRIPTION
Issue: The application initially used Gemini 1.0 Pro Vision (gemini-pro-vision), which has been deprecated as of July 12, 2024. This deprecation caused certain functionalities to fail.

Resolution: Updated the application to use gemini-1.5-flash. The transition was seamless, and all previously failing functionalities are now working as expected.